### PR TITLE
Add MySQL timeout parameter / fix compatibility with MariaDB 10.1 and older

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,33 @@ locker := gomysqllock.NewMysqlLocker(db, gomysqllock.WithRefreshInterval(time.Mi
 #### Obtain Lock With Context
 By default, an attempt to obtain a lock is backed by background context. That means the `Obtain` call would block
 indefinitely. Optionally, an `Obtain` call can be made with user given context which will get cancelled with the given
-context. The following call will give up after a second if the lock was not obtained.
+context.
+
+The following call will give up after a second if the lock was not obtained.
 ```go
 locker := gomysqllock.NewMysqlLocker(db)
 ctxShort, _ := context.WithDeadline(context.Background(), time.Now().Add(time.Second))
 lock, err := locker.ObtainContext(ctxShort, "key")
 ```
+
+#### Obtain Lock With (MySQL) Timeout
+MySQL has the ability to timeout and return if the lock can't be acquired in a given number of seconds.
+This timeout can be specified when using `ObtainTimeout` and `ObtainTimeoutContext`. On timeout, `ErrMySQLTimeout` is returned, and the lock is not obtained.
+
+The following call will give up after a second if the lock was not obtained, using MySQL timeout option:
+```go
+locker := gomysqllock.NewMysqlLocker(db)
+lock, err := locker.ObtainTimeout("key", 1)
+```
+
 #### Know When The Lock is Lost
 Obtained lock has a context which is cancelled if the lock is lost. This is determined while a goroutine keeps pinging the connection. If there is an error while pinging, assuming connection has an error, the context is cancelled. And the lock owner gets notified of the lost lock.
 ```go
 context := lock.GetContext()
 ``` 
+
+### Compatibility
+
+This library is tested (automatically) against MySQL 8 and MariaDB 10.1, and it should work for MariaDB versions >= 10.1 and MySQL versions >= 5.6.
+
+Note that `GET_LOCK` function won't lock indefinitely on MariaDB 10.1 / MySQL 5.6 and older, as `0` or negative value for timeouts are not accepted in those versions. This means that **in MySQL <= 5.6 / MariaDB <= 10.1 you can't use `Obtain` or `ObtainContext`**. To achieve a similar goal, you can use `ObtainTimeout` (and `ObtainTimeoutContext`) using a very high timeout value.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,10 @@ steps:
     docker run -d -p 3306:3306 --name mysql8 -e MYSQL_ALLOW_EMPTY_PASSWORD=yes mysql:8
   displayName: 'Start Mysql docker'
 
+- script: |
+    docker run -d -p 3305:3306 --name mariadb101 -e MYSQL_ALLOW_EMPTY_PASSWORD=yes mariadb:10.1
+  displayName: 'Start old MariaDB docker'
+
 - task: GoTool@0
   displayName: 'Use Go $(GOVERSION)'
   inputs:

--- a/errors.go
+++ b/errors.go
@@ -4,3 +4,5 @@ import "errors"
 
 // ErrGetLockContextCancelled is returned when user given context is cancelled while trying to obtain the lock
 var ErrGetLockContextCancelled = errors.New("context cancelled while trying to obtain lock")
+var ErrMySQLTimeout = errors.New("(mysql) timeout while acquiring the lock")
+var ErrMySQLInternalError = errors.New("internal mysql error acquiring the lock")

--- a/errors.go
+++ b/errors.go
@@ -4,5 +4,9 @@ import "errors"
 
 // ErrGetLockContextCancelled is returned when user given context is cancelled while trying to obtain the lock
 var ErrGetLockContextCancelled = errors.New("context cancelled while trying to obtain lock")
+
+// ErrMySQLTimeout is returned when the MySQL server can't acquire the lock in the specified timeout
 var ErrMySQLTimeout = errors.New("(mysql) timeout while acquiring the lock")
+
+// ErrMySQLInternalError is returned when MySQL is returning a generic internal error
 var ErrMySQLInternalError = errors.New("internal mysql error acquiring the lock")

--- a/locker_client_test.go
+++ b/locker_client_test.go
@@ -110,5 +110,5 @@ func TestMysqlLocker_Obtain_DBScanError(t *testing.T) {
 
 	// setting very long key name shall result into error
 	_, err := locker.Obtain(strings.Repeat("x", 100))
-	assert.Contains(t, err.Error(), "internal mysql error acquiring the lock")
+	assert.Contains(t, err.Error(), "could not read mysql response")
 }


### PR DESCRIPTION
I added two methods to use an explicit timeout, as they might be useful, and this also fixes an incompatibility with older MySQL/MariaDB (tested with 10.1) where `GET_LOCK` does not support `-1` for infinite value.

I added new test cases for the timeout part. I tested it with a build flag (as in tests with older versions current tests will fail on `-1` timeouts), but I'm open to suggestions :-)