### PR TITLE
Fix Vitess support by removing use of `COALESCE()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,6 @@ context := lock.GetContext()
 
 ### Compatibility
 
-This library is tested (automatically) against MySQL 8 and MariaDB 10.1, and it should work for MariaDB versions >= 10.1 and MySQL versions >= 5.6.
+This library is tested (automatically) against MySQL 8 and MariaDB 10.1, and it should work for MariaDB versions >= 10.1, MySQL versions >= 5.6, and Vitess versions >= 15.0.
 
 Note that `GET_LOCK` function won't lock indefinitely on MariaDB 10.1 / MySQL 5.6 and older, as `0` or negative value for timeouts are not accepted in those versions. This means that **in MySQL <= 5.6 / MariaDB <= 10.1 you can't use `Obtain` or `ObtainContext`**. To achieve a similar goal, you can use `ObtainTimeout` (and `ObtainTimeoutContext`) using a very high timeout value.

--- a/lock.go
+++ b/lock.go
@@ -24,7 +24,7 @@ func (l Lock) GetContext() context.Context {
 // Release unlocks the lock
 func (l Lock) Release() error {
 	l.unlocker <- struct{}{}
-	l.conn.ExecContext(context.Background(), "DO RELEASE_LOCK(?)", l.key)
+	l.conn.ExecContext(context.Background(), "SELECT RELEASE_LOCK(?)", l.key)
 	return l.conn.Close()
 }
 

--- a/lock.go
+++ b/lock.go
@@ -24,7 +24,7 @@ func (l Lock) GetContext() context.Context {
 // Release unlocks the lock
 func (l Lock) Release() error {
 	l.unlocker <- struct{}{}
-	l.conn.ExecContext(context.Background(), "SELECT RELEASE_LOCK(?)", l.key)
+	l.conn.ExecContext(context.Background(), "DO RELEASE_LOCK(?)", l.key)
 	return l.conn.Close()
 }
 

--- a/locker_client.go
+++ b/locker_client.go
@@ -64,7 +64,7 @@ func (l MysqlLocker) ObtainTimeoutContext(ctx context.Context, key string, timeo
 
 	row := dbConn.QueryRowContext(ctx, "SELECT GET_LOCK(?, ?)", key, timeout)
 
-	var res sql.NullInt16
+	var res sql.NullInt32
 	err = row.Scan(&res)
 	if err != nil {
 		// mysql error does not tell if it was due to context closing, checking it manually
@@ -82,7 +82,7 @@ func (l MysqlLocker) ObtainTimeoutContext(ctx context.Context, key string, timeo
 		// Note: some MySQL/MariaDB versions (like MariaDB 10.1) does not support -1 as timeout parameters
 		cancelFunc()
 		return nil, ErrMySQLInternalError
-	} else if res.Int16 == 0 {
+	} else if res.Int32 == 0 {
 		// MySQL Timeout
 		cancelFunc()
 		return nil, ErrMySQLTimeout


### PR DESCRIPTION
Vitess supports `GET_LOCK()` and `RELEASE_LOCK()` but does not allow you to call these functions within other functions like `COALESCE()`. This PR switches back to calling `GET_LOCK()` by itself but tests for a `NULL` result instead of coalescing it. This change retains the same compatibility with other MySQL/MariaDB versions while adding Vitess support, so it should be a good compromise to support the widest set of options.

You can see an example here from trying these queries against a Vitess 14 test instance, and can see how the `vtgate` will fail the `COALESCE(GET_LOCK(..`.

```
mysql> SELECT COALESCE(GET_LOCK('foo', 1), 2) FROM dual;
ERROR 1235 (42000): get_lock(:vtg1, :vtg2) allowed only with dual
mysql> SELECT GET_LOCK('foo', 1);
+--------------------+
| get_lock('foo', 1) |
+--------------------+
|                  1 |
+--------------------+
1 row in set (0.01 sec)

mysql> DO RELEASE_LOCK('foo');
Query OK, 0 rows affected (0.01 sec)
```