### PR TITLE
Close db connection whenever failed to retrieve lock to prevent connection leak

### DIFF
--- a/locker_client.go
+++ b/locker_client.go
@@ -66,7 +66,7 @@ func (l MysqlLocker) ObtainTimeoutContext(ctx context.Context, key string, timeo
 
 	var res sql.NullInt32
 	err = row.Scan(&res)
-	if err != nil || res != 1 {
+	if err != nil || !res.Valid || res.Int32 != int32(1) {
 		defer dbConn.Close()
 
 		// mysql error does not tell if it was due to context closing, checking it manually

--- a/locker_client.go
+++ b/locker_client.go
@@ -66,7 +66,9 @@ func (l MysqlLocker) ObtainTimeoutContext(ctx context.Context, key string, timeo
 
 	var res sql.NullInt32
 	err = row.Scan(&res)
-	if err != nil {
+	if err != nil || res != 1 {
+		defer dbConn.Close()
+
 		// mysql error does not tell if it was due to context closing, checking it manually
 		select {
 		case <-ctx.Done():

--- a/locker_client.go
+++ b/locker_client.go
@@ -66,9 +66,9 @@ func (l MysqlLocker) ObtainTimeoutContext(ctx context.Context, key string, timeo
 
 	var res sql.NullInt32
 	err = row.Scan(&res)
-	if err != nil || !res.Valid || res.Int32 != int32(1) {
+	if err != nil {
+		//Close database connection whenever failed to acquire lock
 		defer dbConn.Close()
-
 		// mysql error does not tell if it was due to context closing, checking it manually
 		select {
 		case <-ctx.Done():
@@ -80,11 +80,15 @@ func (l MysqlLocker) ObtainTimeoutContext(ctx context.Context, key string, timeo
 		cancelFunc()
 		return nil, fmt.Errorf("could not read mysql response: %w", err)
 	} else if !res.Valid {
+		//Close database connection whenever failed to acquire lock
+		defer dbConn.Close()
 		// Internal MySQL error occurred, such as out-of-memory, thread killed or others (the doc is not clear)
 		// Note: some MySQL/MariaDB versions (like MariaDB 10.1) does not support -1 as timeout parameters
 		cancelFunc()
 		return nil, ErrMySQLInternalError
 	} else if res.Int32 == 0 {
+		//Close database connection whenever failed to acquire lock
+		defer dbConn.Close()
 		// MySQL Timeout
 		cancelFunc()
 		return nil, ErrMySQLTimeout


### PR DESCRIPTION
We used this library in one of our application to prevent race condition when two cron jobs are running at the same time.
Our cron job runs every hour, the one that failed to retrieve the lock will always have its connection opened.
The connection count increases until the connection pool exhausted and our application crashed.

Please consider merging this into the main branch 😄 